### PR TITLE
Changed master to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ before-release:
 		git status
 		$(error-exit) "Repository is dirty!"
 	fi
-	if [[ $$(git rev-parse HEAD) != $$(git rev-parse origin/master) ]]; then
-		git --no-pager log --oneline --graph origin/master...
-		$(error-exit) "HEAD must point to origin/master!"
+	if [[ $$(git rev-parse HEAD) != $$(git rev-parse origin/main) ]]; then
+		git --no-pager log --oneline --graph origin/main...
+		$(error-exit) "HEAD must point to origin/main!"
 	fi


### PR DESCRIPTION
This pull request makes a minor update to the `before-release` check in the `Makefile`, ensuring it now verifies that `HEAD` points to `origin/main` instead of `origin/master`. This reflects a branch naming convention change.