### PR TITLE
Added fetch depth 0 to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -104,6 +106,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This pull request makes a small but important improvement to the release workflow by ensuring that the full git history is available during job execution. This change helps with tasks that require access to complete commit information, such as changelog generation or versioning.

* Workflow configuration: Updated both jobs in `.github/workflows/release.yml` to set `fetch-depth: 0` when checking out the repository, ensuring the full commit history is available. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R21-R22) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R109-R110)