### PR TITLE
Execute nixfmt only on Linux/Darwin

### DIFF
--- a/.github/workflows/codingstyle.yml
+++ b/.github/workflows/codingstyle.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: yaxitech/nix-install-pkgs-action@v7
         name: Install nixfmt
         with:

--- a/.github/workflows/codingstyle.yml
+++ b/.github/workflows/codingstyle.yml
@@ -18,6 +18,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - uses: yaxitech/nix-install-pkgs-action@v7
+        name: Install nixfmt
+        with:
+          packages: "nixpkgs#nixfmt-rfc-style"
       - uses: pre-commit/action@v3.0.1
 
   nixfmt:
@@ -30,4 +34,4 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Check Nix formatting
         run: |
-          nix-shell -p nixfmt-classic --run "find . -name '*.nix' -exec nixfmt --check {} \;"
+          nix-shell -p nixfmt-rfc-style --run "find . -name '*.nix' -exec nixfmt --check {} \;"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
     hooks:
       - id: nixfmt
         name: nixfmt
-        entry: bash -c 'case "$(uname -s)" in MINGW*|CYGWIN*|MSYS*) exit 0;; Linux*|Darwin*) nixfmt "$@";; *) exit 1;; esac' --
+        entry: bash -c 'case "$(uname -s)" in Linux*|Darwin*) nixfmt "$@";; *) exit 0;; esac' --
         language: system
         files: \.nix$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
     hooks:
       - id: nixfmt
         name: nixfmt
-        entry: bash -c 'case "$(uname -s)" in Windows*) exit 0;; Linux*|Darwin*) nixfmt "$@";; *) exit 1;; esac' --
+        entry: bash -c 'case "$(uname -s)" in MINGW*|CYGWIN*|MSYS*) exit 0;; Linux*|Darwin*) nixfmt "$@";; *) exit 1;; esac' --
         language: system
         files: \.nix$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,7 @@ repos:
     rev: "v1.0.0"
     hooks:
       - id: nixfmt
+        name: nixfmt
+        entry: bash -c 'case "$(uname -s)" in Windows*) exit 0;; Linux*|Darwin*) nixfmt "$@";; *) exit 1;; esac' --
+        language: system
+        files: \.nix$


### PR DESCRIPTION
Hopes and prayers
This pull request updates the `nixfmt` hook configuration in `.pre-commit-config.yaml` to improve cross-platform compatibility. The hook now uses a shell command to ensure it only runs on Linux and macOS systems, and it explicitly specifies the files it should process.

Pre-commit hook improvements:

* Updated the `nixfmt` hook to use a shell command that checks the operating system, running only on Linux and macOS and skipping on Windows.
* Set the `language` to `system` and restricted the hook to files matching the `\.nixHopes and prayers
 pattern for more precise execution.